### PR TITLE
break overlong promo-box text

### DIFF
--- a/scss/_related-box.scss
+++ b/scss/_related-box.scss
@@ -33,6 +33,7 @@
 	line-height: 27px;
 	margin: 8px 16px;
 	color: getColor('cold-3');
+	word-wrap: break-word;
 	p {
 		margin: 0;
 	}


### PR DESCRIPTION
@i-like-robots 
To address promobox headline text overflowing its container (in particular when an article is prepared for printing, because the full link href is included).
Although it looks like this problem is only really on IE at the moment, I think that this fix will also prevent unusually long words from overflowing on other browsers, also.
Jira issue [here](https://jira.ft.com/browse/NFT-243).