### PR TITLE
Updates the style of images with long captions

### DIFF
--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -1,4 +1,5 @@
 .n-content-image {
+	display: table;
 	margin: 0 auto 1em;
 	max-width: 100%;
 	clear: left;
@@ -40,6 +41,8 @@
 
 .n-content-image__caption {
 	@include oTypographySans(s);
+	display: table-caption;
+	caption-side: bottom;
 	font-style: italic;
 	color: getColor('cold-1');
 	margin-top: 0.5em;


### PR DESCRIPTION
Previously the if an image had a long caption it was forcing the width
of the `<figure>` to its width rather than the width of the image.

## Before
<img width="704" alt="screen shot 2016-03-22 at 10 28 48" src="https://cloud.githubusercontent.com/assets/524573/13949143/8527bd66-f01b-11e5-9d19-c9e5db861d3d.png">

## After
<img width="698" alt="screen shot 2016-03-22 at 10 29 29" src="https://cloud.githubusercontent.com/assets/524573/13948969/e1901b80-f01a-11e5-9b30-b024bff3b56c.png">


## Before - large image without long caption
<img width="694" alt="screen shot 2016-03-22 at 10 30 34" src="https://cloud.githubusercontent.com/assets/524573/13949187/9d9864f4-f01b-11e5-9144-571062f99d7b.png">

## After - large image without long caption
<img width="688" alt="screen shot 2016-03-22 at 10 29 54" src="https://cloud.githubusercontent.com/assets/524573/13949200/b0b69628-f01b-11e5-93b5-5bd423f06057.png">
