### PR TITLE
Switches to an up arrow icon when box is expanded

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -24,8 +24,11 @@
 			color: getColor('cold-2');
 			text-decoration: none;
 		}
-		&[aria-pressed] i {
+		&[aria-expanded="true"] i {
 			@include nextIcon(arrow-up, getColor('teal-1'), 12);
+			&:hover {
+				@include nextIcon(arrow-up, getColor('cold-2'), 12);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Now when the button displays "Show less" the icon will also switch to an
up arrow.

![show-more](https://cloud.githubusercontent.com/assets/524573/13951585/e0f7d12c-f029-11e5-849a-c78f0d2974c7.gif)
