### PR TITLE
Simplify the mega-old nListsItemLink mixin a bit

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -81,19 +81,7 @@
 }
 
 @mixin nListsItemLink($use-case: n-lists) {
-	@if($use-case == n-lists-inversed) {
-		@include nLinksTopic($inversed: true);
-	} @else if ($use-case == n-lists-links-inversed) {
-		@include nLinksBody($inversed: true);
-		@include oTypographySansBold(s);
-		text-transform: uppercase;
-	} @else if ($use-case == n-lists-links) {
-		@include nLinksBody();
-		@include oTypographySansBold(s);
-		text-transform: uppercase;
-	} @else {
-		@include nLinksTopic();
-	}
+	@include nLinksTopic();
 	display: block;
 	padding: 2px 15px 2px $spacing-unit/2;
 	position: relative;


### PR DESCRIPTION
The 3 things that still call this mixin all fall into the `else`, so we can remove the conditionals altogether.

(Less of a yak shave than removing it completely.)