### PR TITLE
Use Metric for promo box headers

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -46,13 +46,11 @@
 }
 
 @mixin nContentBoxTitleText() {
-	@include oTypographySerifDisplay('m', $load-progressively: true);
-	color: getColor('cold-1');
+	@include oTypographySansBold('m', $load-progressively: true);
 	display: inline-block;
 	padding: 10px;
 	padding-bottom: 0;
 	margin: 0;
-	font-weight: 900;
 	background-color: inherit;
 	a {
 		color: getColor('cold-1');


### PR DESCRIPTION
(so we don't load an extra font for them)