### PR TITLE
halve the opacity of n-content-layout background

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -4,7 +4,7 @@
 	clear: both;
 	padding: 0 oTypographySpacingSize(3);
 
-	background-color: oColorsGetPaletteColor('wheat');
+	background-color: rgba(oColorsGetPaletteColor('wheat'), 0.5);
 
 	&[data-layout-width="full-grid"] {
 		@include oGridRespondTo($until: L) {


### PR DESCRIPTION
from
<img width="599" alt="screen shot 2017-09-06 at 16 08 44" src="https://user-images.githubusercontent.com/4750238/30119454-b191fd98-931d-11e7-8cd4-d8707bcb4324.png">
to 
<img width="598" alt="screen shot 2017-09-06 at 16 08 34" src="https://user-images.githubusercontent.com/4750238/30119453-b1673f2c-931d-11e7-8f02-cfd6699d5919.png">