### PR TITLE
Make layout widths and names work

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -11,5 +11,5 @@
 @import "scss/related-box";
 @import "scss/tags";
 @import "scss/video";
-@import "scss/layout";
+@import "scss/layout/main";
 @import "scss/print";

--- a/scss/layout/_aside.scss
+++ b/scss/layout/_aside.scss
@@ -9,7 +9,7 @@
 			padding-right: oTypographySpacingSize(3);
 		}
 
-		[class^=n-content-heading-] {
+		.n-content-layout__container > [class^=n-content-heading-] {
 			padding-left: oTypographySpacingSize(3);
 			padding-right: oTypographySpacingSize(3);
 		}

--- a/scss/layout/_aside.scss
+++ b/scss/layout/_aside.scss
@@ -1,0 +1,17 @@
+.n-content-layout-set,
+.n-content-layout {
+
+	&[data-layout-name="aside"] {
+		background-color: rgba(oColorsGetPaletteColor('wheat'), 0.5);
+
+		.n-content-layout__slot {
+			padding-left: oTypographySpacingSize(3);
+			padding-right: oTypographySpacingSize(3);
+		}
+
+		[class^=n-content-heading-] {
+			padding-left: oTypographySpacingSize(3);
+			padding-right: oTypographySpacingSize(3);
+		}
+	}
+}

--- a/scss/layout/_card.scss
+++ b/scss/layout/_card.scss
@@ -1,0 +1,17 @@
+.n-content-layout-set,
+.n-content-layout {
+
+	&[data-layout-name="card"] {
+		background-color: rgba(oColorsGetPaletteColor('wheat'), 0.5);
+
+		.n-content-layout__slot {
+			padding-left: oTypographySpacingSize(3);
+			padding-right: oTypographySpacingSize(3);
+		}
+
+		[class^=n-content-heading-] {
+			padding-left: oTypographySpacingSize(3);
+			padding-right: oTypographySpacingSize(3);
+		}
+	}
+}

--- a/scss/layout/_card.scss
+++ b/scss/layout/_card.scss
@@ -9,7 +9,7 @@
 			padding-right: oTypographySpacingSize(3);
 		}
 
-		[class^=n-content-heading-] {
+		.n-content-layout__container > [class^=n-content-heading-] {
 			padding-left: oTypographySpacingSize(3);
 			padding-right: oTypographySpacingSize(3);
 		}

--- a/scss/layout/_default.scss
+++ b/scss/layout/_default.scss
@@ -1,0 +1,16 @@
+/*TODO: remove this file once all the existing layouts have the correct name */
+
+.n-content-layout-set,
+.n-content-layout {
+	background-color: rgba(oColorsGetPaletteColor('wheat'), 0.5);
+
+	.n-content-layout__slot {
+		padding-left: oTypographySpacingSize(3);
+		padding-right: oTypographySpacingSize(3);
+	}
+
+	.n-content-layout__container > [class^=n-content-heading-] {
+		padding-left: oTypographySpacingSize(3);
+		padding-right: oTypographySpacingSize(3);
+	}
+}

--- a/scss/layout/_main.scss
+++ b/scss/layout/_main.scss
@@ -1,35 +1,11 @@
+@import './widths';
+@import './aside';
+@import './card';
+
 .n-content-layout {
 	// margin considers p margin bottom of 28px to equal 36px on both sides
 	@include oTypographyMargin($top: 2, $bottom: 9);
-	clear: both;
-
-	background-color: rgba(oColorsGetPaletteColor('wheat'), 0.5);
-
-	&[data-layout-width="full-grid"] {
-		@include oGridRespondTo($until: L) {
-			width: 100%;
-			margin-left: -1 * oGridGutter();
-		}
-
-		@include oGridRespondTo(L) {
-			position: relative;
-			left: calc(75% + 10px);
-			width: 100vw;
-			margin-left: -50vw;
-
-			.n-content-layout__container {
-				@include oGridContainer;
-			}
-		}
-
-		@include oGridRespondTo(XL) {
-			left: calc(75% - 15px);
-		}
-	}
-
 }
-
-
 
 .n-content-layout__container {
 	display: flex;
@@ -46,18 +22,13 @@
 		@include oTypographyMargin($top: 0, $bottom: 1);
 		@include oTypographyPadding($bottom: 2);
 		border-bottom: 2px solid getColor(paper);
-		padding-left: oTypographySpacingSize(3);
-		padding-right: oTypographySpacingSize(3);
 		box-sizing: border-box;
 	}
-
 }
 
 .n-content-layout__slot {
 	min-width: 0; //fix for images going outside the container
 	max-width: 100%; //fix overflow on IE
-	padding-left: oTypographySpacingSize(3);
-	padding-right: oTypographySpacingSize(3);
 	flex-basis: 100%;
 	@include oTypographyMargin($top: 1, $bottom: 3);
 	@include oGridRespondTo(M) {
@@ -66,7 +37,7 @@
 			margin-left: 16px;
 		}
 
-		&--wide {
+		&[data-slot-width="wide"] {
 			flex: 2;
 		}
 	}

--- a/scss/layout/_main.scss
+++ b/scss/layout/_main.scss
@@ -1,4 +1,5 @@
 @import './widths';
+@import './default';
 @import './aside';
 @import './card';
 

--- a/scss/layout/_widths.scss
+++ b/scss/layout/_widths.scss
@@ -1,0 +1,32 @@
+.n-content-layout-set,
+.n-content-layout {
+	clear: both;
+
+
+	&[data-layout-width="full-grid"] {
+		@include oGridRespondTo($until: L) {
+			width: 100%;
+			margin-left: -1 * oGridGutter();
+		}
+
+		@include oGridRespondTo(L) {
+			position: relative;
+			left: calc(75% + 10px);
+			width: 100vw;
+			margin-left: -50vw;
+
+			.n-content-layout__container {
+				@include oGridContainer;
+			}
+		}
+
+		@include oGridRespondTo(XL) {
+			left: calc(75% - 15px);
+		}
+	}
+
+	&[data-layout-width="inset-left"] {
+		@include nLayoutInset();
+	}
+
+}


### PR DESCRIPTION
 🐿2.5.10

* By default, layouts have no background
* [data-layout-name="aside"], [data-layout-name="card"] get a background
* add [data-layout-width="inset-left"]
* [data-slot-width="wide"]
* All the data-layout-* apply to both layouts and layoutsets