### PR TITLE
use non-transparent bg for cards and asides

### DIFF
--- a/scss/layout/_aside.scss
+++ b/scss/layout/_aside.scss
@@ -2,7 +2,7 @@
 .n-content-layout {
 
 	&[data-layout-name="aside"] {
-		background-color: rgba(oColorsGetPaletteColor('wheat'), 0.5);
+		background-color: oColorsGetTint('wheat', 100);
 
 		.n-content-layout__slot {
 			padding-left: oTypographySpacingSize(3);

--- a/scss/layout/_card.scss
+++ b/scss/layout/_card.scss
@@ -2,7 +2,7 @@
 .n-content-layout {
 
 	&[data-layout-name="card"] {
-		background-color: rgba(oColorsGetPaletteColor('wheat'), 0.5);
+		background-color: oColorsGetTint('wheat', 100);
 
 		.n-content-layout__slot {
 			padding-left: oTypographySpacingSize(3);

--- a/scss/layout/_timeline.scss
+++ b/scss/layout/_timeline.scss
@@ -3,30 +3,30 @@
 
 	&[data-layout-name="timeline"] {
 		.n-content-heading-3 {
-			border-bottom: 0px;
-			padding-bottom: 0px;
+			border-bottom: 0;
+			padding-bottom: 0;
 		}
 		.n-content-heading-4 {
 			padding-top: 10px;
-			border-bottom: 0px;
+			border-bottom: 0;
 			@include oTypographySansBold($scale: 8, $progressive: true);
 		}
 		.n-content-layout__slot {
 			flex-basis: 100%;
 			padding-left: 30px;
-			margin-left: 0px;
-			margin-top: 0px;
-			margin-bottom: 0px;
+			margin-left: 0;
+			margin-top: 0;
+			margin-bottom: 0;
 			position: relative;
 			&:before {
 				content: '';
 				width: 2px;
-				background: #000;
+				background: oGolorsGetPaletteColor('black');
 				height: 100%;
 				display: block;
 				position: absolute;
 				left: 5px;
-				top: 0px;
+				top: 0;
 			}
 			.n-content-heading-5 {
 				position: relative;
@@ -40,7 +40,7 @@
 						height: 8px;
 						width: 8px;
 						border-radius: 50%;
-						background-color: #000;
+						background-color: oGolorsGetPaletteColor('black');
 					}
 				}
 			}


### PR DESCRIPTION
Bit warmer, less hacky

before 
![image](https://user-images.githubusercontent.com/447559/34989664-52386200-fabb-11e7-9219-cc12c0ecd090.png)
after 
![image](https://user-images.githubusercontent.com/447559/34989672-59f67e14-fabb-11e7-9bd2-5c2cb89bca28.png)

