### PR TITLE
added support for otable large layout

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -111,3 +111,13 @@
 		clear: both;
 	}
 }
+
+@mixin nLayoutInsetRight() {
+	margin-bottom: oTypographySpacingSize(7);
+	@include oGridRespondTo(S) {
+		@include oGridColspan(5, $width-only: true);
+		margin-left: oTypographySpacingSize(7);
+		float: right;
+		clear: both;
+	}
+}

--- a/scss/layout/_widths.scss
+++ b/scss/layout/_widths.scss
@@ -28,4 +28,7 @@
 		@include nLayoutInset();
 	}
 
+	&[data-layout-width="inset-right"] {
+		@include nLayoutInsetRight();
+	}
 }


### PR DESCRIPTION
- added styles to support otable large layout option: inset-right
- trello card: https://trello.com/c/xPAfiAf5/18-set-large-screen-layout
- related PR: https://github.com/Financial-Times/next-es-interface/pull/1313
- this change is non breaking, fully backward compatible

 🐿 v2.12.0