### PR TITLE
added support for otable full-bleed option

### DIFF
--- a/scss/layout/_widths.scss
+++ b/scss/layout/_widths.scss
@@ -2,6 +2,19 @@
 .n-content-layout {
 	clear: both;
 
+	&[data-layout-width="full-bleed"] {
+		width: 100vw;
+		margin-left: -50vw;
+
+		left: calc(50% + 120px);
+		z-index: 1;
+
+		.n-content-layout__container {
+			padding-left: 40px;
+			padding-right: 40px;
+			width: auto;
+		}
+	}
 
 	&[data-layout-width="full-grid"] {
 		@include oGridRespondTo($until: L) {


### PR DESCRIPTION
- the padding 40px is needed to handle the feedback button
- said button size is set in px in n-feedback, so it does make sense to do the same here

related to PR: https://github.com/Financial-Times/next-es-interface/pull/1315

 🐿 v2.12.0