### PR TITLE
feat: remove old data-table styles cause we are using o-table now

### DIFF
--- a/scss/_body.scss
+++ b/scss/_body.scss
@@ -53,47 +53,11 @@
 		position: relative;
 	}
 
-	// DATA TABLES
-	.data-table {
-		margin-top: 20px;
-		border-spacing: 0;
-		width: 100%;
-
-		caption,
-		thead {
-			text-align: left;
-		}
-		caption {
-			font-weight: 500;
-			text-transform: uppercase;
-		}
-		thead,
-		tbody {
-			&:before {
-				content: "";
-				display: block;
-				height: 10px;
-			}
-		}
-		tbody tr:nth-child(odd) {
-			background-color: getColor('black-10');
-		}
-		th,
-		td {
-			vertical-align: top;
-		}
-		th {
-			font-weight: 500;
-		}
-		td {
-			padding: 5px 10px;
-		}
-	}
-
 	.subhead--crosshead,
 	.n-content-heading-2 {
 		@include nContentHeading2;
 	}
+
 	.subhead--standard,
 	.n-content-heading-3 {
 		@include nContentHeading3;
@@ -102,7 +66,6 @@
 	.n-content-heading-4 {
 		@include nContentHeading4;
 	}
-
 
 	.n-content-heading-5 {
 		@include nContentHeading5;


### PR DESCRIPTION
AMP, App, ft.com are now using the o-table component. It seems that there are no other application inside ft.com that are using this styles directly from n-content-body so it should be safe to delete them.

Reference to [trello ticket](https://trello.com/c/4tgOPHbC/31-pre-live-remove-data-styles-from-n-content-body)