### PR TITLE
Remove deprecated oQuote call

### DIFF
--- a/scss/_blockquotes.scss
+++ b/scss/_blockquotes.scss
@@ -5,12 +5,6 @@
 	@include oQuoteStandard();
 	@include oTypographyMargin($bottom: 7);
 
-	&:before {
-		content: '';
-		display: block;
-		@include oQuoteStandardIcon();
-	}
-
 	cite {
 		@include oQuoteCite();
 		@include oQuoteStandardCite();


### PR DESCRIPTION
`oQuoteStandardIcon()` was deprecated some time ago and is no longer
used so remove it from here so that we stop getting warnings on build.