### PR TITLE
Add nContentHeading6 styles

### DIFF
--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -20,6 +20,11 @@
 	@include nContentMargins();
 }
 
+@mixin nContentHeading6 {
+	@include oTypographyHeadingLevel6();
+	@include nContentMargins();
+}
+
 @mixin nContentMargins($headingTop: 0, $headingBottom: 1, $pSize: 1, $elementSize: 5) {
 	@include oTypographyMargin($top: $headingTop, $bottom: $headingBottom);
 


### PR DESCRIPTION
Currently [breaks](https://circleci.com/gh/Financial-Times/next-article/18540) when building `_body.scss` because `nContentHeading6` does not exist. From the changes of https://github.com/Financial-Times/n-content-body/pull/107.

`o-typography` says [heading level 6 is for internal/whitelabel use](https://github.com/Financial-Times/o-typography/blob/9dacce1dd9f6256fcad21c1ffc36ce8cce47f936/src/scss/use-cases/_headings.scss#L51-L55), but I think that's fine here. I don't think it will be used in practice, but I don't see anything wrong with adding it here for completeness.

Also created this issue to prevent this from happening in future: https://github.com/Financial-Times/n-content-body/issues/108

