### PR TITLE
Remove reference to `nContentHeading6` in captions

### DIFF
--- a/scss/_body.scss
+++ b/scss/_body.scss
@@ -97,11 +97,9 @@
 .n-content-body__caption--h3 {
 	@include nContentHeading4;
 }
-.n-content-body__caption--h4 {
-	@include nContentHeading5;
-}
+.n-content-body__caption--h4,
 .n-content-body__caption--h5 {
-	@include nContentHeading6;
+	@include nContentHeading5;
 }
 
 // Hide caption

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -20,11 +20,6 @@
 	@include nContentMargins();
 }
 
-@mixin nContentHeading6 {
-	@include oTypographyHeadingLevel6();
-	@include nContentMargins();
-}
-
 @mixin nContentMargins($headingTop: 0, $headingBottom: 1, $pSize: 1, $elementSize: 5) {
 	@include oTypographyMargin($top: $headingTop, $bottom: $headingBottom);
 


### PR DESCRIPTION
Previously https://github.com/Financial-Times/n-content-body/pull/109, didn't fix the issue. The build still [breaks](https://circleci.com/gh/Financial-Times/next-article/18541) when compiling `oTypographyHeadingLevel6`, so reverting that PR, and using `h4` styles for `.n-content-body__caption--h5` instead 🤞 