### PR TITLE
Add missing h6 style

### DIFF
--- a/scss/_body.scss
+++ b/scss/_body.scss
@@ -98,7 +98,8 @@
 	@include nContentHeading4;
 }
 .n-content-body__caption--h4,
-.n-content-body__caption--h5 {
+.n-content-body__caption--h5,
+.n-content-body__caption--h6 {
 	@include nContentHeading5;
 }
 


### PR DESCRIPTION
Use `nContentHeading5` for `h6` as that is the [lowest heading style supported](https://github.com/Financial-Times/n-content-body/pull/110).

Should have gone into https://github.com/Financial-Times/n-content-body/pull/107, but was left out 😬 

It would be passed through: https://github.com/Financial-Times/next-es-interface/blob/170b9e664fe913d0529586d252289f6af8cb7265/server/transformers/plugins/article/concerns/transform-data-tables.js#L90