### PR TITLE
Make big numbers without paragraphs look correct.

### DIFF
--- a/scss/_big-number.scss
+++ b/scss/_big-number.scss
@@ -2,7 +2,7 @@
 	color: getColor('black');
 
 	p {
-		margin: 5px 0 0;
+		margin: 0;
 	}
 	// big numbers not inside a layout should float
 	.n-content-body > & {
@@ -12,8 +12,11 @@
 
 .n-content-big-number__title {
 	@include oTypographySansBold($scale: 8, $progressive: true);
+	display: block;
+	margin: 5px 0;
 }
 
 .n-content-big-number__content {
 	@include oTypographySans($scale: 1, $line-height: 22px, $progressive: true);
+	display: block;
 }

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,0 +1,13 @@
+module.exports = {
+	files: {
+		allow: [
+			'.snyk',
+			'CODEOWNERS'
+		],
+		allowOverrides: []
+	},
+	strings: {
+		deny: [],
+		denyOverrides: []
+	}
+};


### PR DESCRIPTION
Big numbers in the new UPP schema do not allow for paragraph tags (which
kind of makes sense - the `<p>` tags are a little redundant here and I think a hangover from Methode).

The current styles however look a bit odd without paragraph tags - so these
changes make it look okay with/without.

Before:
![Screenshot 2019-07-19 at 12 38 43](https://user-images.githubusercontent.com/1978880/61532854-19816b00-aa23-11e9-9192-09bf69e3476b.png)

After:
![Screenshot 2019-07-19 at 12 39 23](https://user-images.githubusercontent.com/1978880/61532851-15ede400-aa23-11e9-898c-83c8219055e5.png)


 🐿2.5.10