### PR TITLE
Add integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,7 @@ node_modules/@financial-times/n-gage/index.mk:
 
 -include node_modules/@financial-times/n-gage/index.mk
 
-test: verify
+test: integration-test verify
+
+integration-test:
+	npx jest test/integration

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "prepush": "make verify -j3",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
+  },
+  "engines": {
+    "node": "8.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "devDependencies": {
     "@financial-times/n-gage": "^3.6.0",
     "bower": "^1.8.8",
+    "jest": "^24.8.0",
     "lintspaces-cli": "^0.1.1",
+    "node-sass": "^4.12.0",
     "snyk": "^1.167.2"
   },
   "scripts": {

--- a/test/integration/compile-main.test.js
+++ b/test/integration/compile-main.test.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const sass = require('node-sass');
+
+const BASE_PATH = path.join(__dirname, '../../');
+const MAIN_FILE = path.join(BASE_PATH, 'main.scss');
+
+async function compile({ file, includePaths }) {
+	return new Promise((resolve, reject) => {
+		sass.render({
+			file,
+			includePaths
+		}, function(err, result) {
+			if (err) {
+				return reject(err);
+			}
+			resolve(result);
+		});
+	});
+}
+
+describe('Compile scss file', () => {
+	test('main.scss', async () => {
+		const result = await compile({
+			file: MAIN_FILE,
+			includePaths: [
+				path.join(BASE_PATH, 'bower_components'),
+				path.join(BASE_PATH, 'node_modules/@financial-times'),
+			]
+		});
+		expect(result).toBeTruthy();
+	});
+});


### PR DESCRIPTION
If `n-content-body` has `scss` compilation problems, it's not caught until downstream, when it is included eg, `next-article`. This fix adds an integration test to compile `main.scss` when testing on CircleCI, so the compilation errors can be caught in this repo before problems get shipped out.

Example of failing build: https://circleci.com/gh/Financial-Times/n-content-body/1435

Fixes https://github.com/Financial-Times/n-content-body/issues/108