### PR TITLE
Remove node version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,5 @@
     "prepush": "make verify -j3",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
-  },
-  "engines": {
-    "node": "8.16.0"
   }
 }


### PR DESCRIPTION
node v8 end of life is 2019-12-31. As n-content-body only uses node
locally, remove the node version from package.json

https://nodejs.org/en/about/releases/