### PR TITLE
Use paragraph sizes from next-article

### DIFF
--- a/scss/_body.scss
+++ b/scss/_body.scss
@@ -8,7 +8,7 @@
 
 	> p,
 	.n-content-layout__slot > p {
-		@include oTypographySerif(1);
+		@include oTypographySans($scale: (default: 1, XL: 2), $line-height: 1.6);
 		margin: 0 0 oSpacingByName('s6');
 
 		a {


### PR DESCRIPTION
This was being set in next-article to override what was set here. Moving
this into n-content-body will let us use the same sizes in other
applications. 🐿 v2.12.5