### PR TITLE
Fix wrong font on body text - use serif on paragraphs

### DIFF
--- a/scss/_body.scss
+++ b/scss/_body.scss
@@ -8,7 +8,7 @@
 
 	> p,
 	.n-content-layout__slot > p {
-		@include oTypographySans($scale: (default: 1, XL: 2), $line-height: 1.6);
+		@include oTypographySerif($scale: (default: 1, XL: 2), $line-height: 1.6);
 		margin: 0 0 oSpacingByName('s6');
 
 		a {


### PR DESCRIPTION
Fixes typo that used `oTypographySans` mixin instead of `oTypographySerif`.

See [incident report](https://github.com/Financial-Times/next-bugs/issues/253).