### PR TITLE
Use new editorial quote style.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "n-ui-foundations": "^4.0.0",
-    "o-quote": "^4.0.1",
+    "o-quote": "^4.1.2",
     "o-editorial-typography": "^1.0.0"
   }
 }

--- a/scss/_blockquotes.scss
+++ b/scss/_blockquotes.scss
@@ -1,13 +1,10 @@
 @import 'o-quote/main';
 
 .n-content-blockquote {
-	@include oQuoteBase();
-	@include oQuoteStandard();
+	@include oQuoteEditorial();
 	margin-bottom: oSpacingByName('s8');
 
 	cite {
-		@include oQuoteStandardCite();
-		@include oQuoteStandardCiteAuthor();
-		@include oQuoteBaseCite();
+		@include oQuoteEditorialCiteAuthor();
 	}
 }


### PR DESCRIPTION
Designed by Josh in the Content Innovation Team.
Background: https://github.com/Financial-Times/o-quote/issues/51

demo: https://www.ft.com/__origami/service/build/v2/demos/o-quote@4.1.2/editorial?brand=master
<img width="581" alt="Screenshot 2020-04-24 at 11 12 43" src="https://user-images.githubusercontent.com/10405691/80201783-895cfb80-861c-11ea-8fdb-ff193b8268a3.png">
