### PR TITLE
Upgrade n-ui-foundations ^4.0.0 -> ^6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ plus common / utility classes used across article elements
 
 - article heading styles (eg. headline, standfirst, date, byline)
 - onward journey (eg. recommended reads, more-ons, story packages)
+
+
+## Migration guides
+
+### v8 to v9
+
+v9 upgrades its version of `n-ui-foundations` from ^4.0.0 to ^6.0.0.
+
+Please read the [`n-ui-foundations` v5 to v6 migration notes](https://github.com/Financial-Times/n-ui-foundations#user-content-v5-to-v6) for details of the required amends to accommodate the v6 changes (snappy grid is no longer output as default), which explains the basis for the below change required by apps consuming this component:
+
+- Find and replace `n-content-layout__container` classes with `n-content-layout__container n-content-layout__container--snappy`.
+```diff
+-<div class="n-content-layout__container"></div>
++<div class="n-content-layout__container n-content-layout__container--snappy"></div>
+```

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "n-ui-foundations": "^4.0.0",
+    "n-ui-foundations": "^6.0.0",
     "o-quote": "^4.0.1",
     "o-editorial-typography": "^1.0.0"
   }


### PR DESCRIPTION
Jira card: https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-84.

I have `bower link`ed this component and run locally on `next-article` (https://www.ft.com/kitchenus-sinkus-articlus). `next-article` is a bit fiddly as it imports `n-ui-foundations` from several different Bower dependencies, as well as importing it directly in its own `bower.json`.

Therefore to get it working, I had to apply the changes required in the [`n-ui-foundations` Migration guide v5 to v6](https://github.com/Financial-Times/n-ui-foundations#user-content-v5-to-v6) (e.g. `@include oGridContainer($grid-mode: 'snappy');`) to a couple of the SASS files of my locally-running instance (`client/components/grid/_helpers.scss` and `client/components/grid/package.scss`). These changes will need to be made to `next-article` when it performs its own `n-ui-foundations` v5 -> v6 migration.

For apps consuming this component, there are required changes when upgrading to v9 (i.e. the version that will include the changes of this PR). These are detailed in a README migration guide which has been added in this PR. The reason that `n-content-layout__container--snappy` is required rather than `o-grid-container--snappy` is that the latter class is overridden by more specific styles, and so we must use the former class to apply to snappy styling.

To get this working locally for `next-article` I made this change in `server/transforms/full-bleed-wrapper.js b/server/transforms/full-bleed-wrapper.js`:
```diff
- pictures.addClass('n-content-layout__container').wrap(wrapper);
+ pictures.addClass('n-content-layout__container n-content-layout__container--snappy').wrap(wrapper);
```

#### References:
- [`n-ui-foundations` Migration guide v5 to v6](https://github.com/Financial-Times/n-ui-foundations#user-content-v5-to-v6).