### PR TITLE
Use the `o-editorial-layout` component.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "n-ui-foundations": "^6.0.0",
     "o-quote": "^4.1.2",
-    "o-editorial-typography": "^1.0.0"
+    "o-editorial-typography": "^1.1.0",
+    "o-editorial-layout": "^1.3.0"
   }
 }

--- a/scss/_body.scss
+++ b/scss/_body.scss
@@ -1,16 +1,24 @@
+@import 'o-spacing/main';
+@import "o-typography/main";
+@import "o-editorial-typography/main";
+@import "o-editorial-layout/main";
+
 //ARTICLE BODY ELEMENTS
 .n-content-body {
 
 	// STANDARD TYPOGRAPHY AND ELEMENTS
-	@include oTypographySerif($scale: 1, $line-height: 28px, $include-progressive: false);
-	margin-bottom: 40px;
-	-webkit-font-smoothing: antialiased;
+	@include oEditorialTypographyBody();
+	margin-bottom: oSpacingByIncrement(10);
+
+	p {
+		// style paragraphs in relation to sibling elements,
+		// headings etc, without including typographic styles
+		// again which are inherited from .n-content-body
+		@include oEditorialLayoutBodyWithoutTypography();
+	}
 
 	> p,
 	.n-content-layout__slot > p {
-		@include oTypographySerif($scale: (default: 1, XL: 2), $line-height: 1.6);
-		margin: 0 0 oSpacingByName('s6');
-
 		a {
 			@include oTypographyLink;
 		}
@@ -42,7 +50,7 @@
 	}
 
 	strong {
-		font-weight: 600;
+		@include oTypographySerif($weight: 'bold', $include-font-family: false);
 	}
 
 	// BLOCKQUOTES
@@ -87,19 +95,19 @@
 // Shift caption headings down one, as h1 is the highest caption level,
 // but we want h2 to be the highest heading style possible
 .n-content-body__caption--h1 {
-	@include nContentHeading2;
+	@include oEditorialTypographyHeading($level: 2);
 }
 .n-content-body__caption--auto, // Default style
 .n-content-body__caption--h2 {
-	@include nContentHeading3;
+	@include oEditorialTypographyHeading($level: 3);
 }
 .n-content-body__caption--h3 {
-	@include nContentHeading4;
+	@include oEditorialTypographyHeading($level: 4);
 }
 .n-content-body__caption--h4,
 .n-content-body__caption--h5,
 .n-content-body__caption--h6 {
-	@include nContentHeading5;
+	@include oEditorialTypographyHeading($level: 5);
 }
 
 // Hide caption

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -1,28 +1,29 @@
-@import "o-editorial-typography/main";
+@import "o-editorial-layout/main";
 
 @mixin nContentHeading2 {
-	@include oEditorialTypographyHeading($level: 2);
-	@include nContentMargins($headingTop: 8);
+	@include oEditorialLayoutHeading($level: 2);
 	// trigger a new formatting context so it won't run into floats
 	overflow: hidden;
 }
 
 @mixin nContentHeading3 {
-	@include oEditorialTypographyHeading($level: 3);
-	@include nContentMargins();
+	@include oEditorialLayoutHeading($level: 3);
 }
 
 @mixin nContentHeading4 {
-	@include oEditorialTypographyHeading($level: 4);
-	@include nContentMargins($headingBottom: 3);
+	@include oEditorialLayoutHeading($level: 4);
 }
 
 @mixin nContentHeading5 {
-	@include oEditorialTypographyHeading($level: 5);
-	@include nContentMargins();
+	@include oEditorialLayoutHeading($level: 5);
 }
 
+/// @deprecated - Use o-editorial-layout instead.
 @mixin nContentMargins($headingTop: 0, $headingBottom: 1) {
+	@warn 'The mixin `nContentMargins` is deprecated. ' +
+	'To match the margin of article headings use the ' +
+	'`o-editorial-layout` component.';
+
 	margin-top: oSpacingByIncrement($headingTop);
 	margin-bottom: oSpacingByIncrement($headingBottom);
 

--- a/scss/layout/_main.scss
+++ b/scss/layout/_main.scss
@@ -34,8 +34,6 @@
 	min-width: 0; //fix for images going outside the container
 	max-width: 100%; //fix overflow on IE
 	flex-basis: 100%;
-	margin-top: oSpacingByName('s1');
-	margin-bottom: oSpacingByName('s3');
 	@include oGridRespondTo(M) {
 		flex: 1 1 1px;
 		& + .n-content-layout__slot {
@@ -52,14 +50,29 @@
 	}
 }
 
-//Font overrides for slot content
-.n-content-body .n-content-layout__slot {
-	> p,
-	> ul > li {
-		@include oTypographySans($scale: 1, $line-height: 22px);
-	}
-	> p {
+// Overrides for slot content
+// It is difficult to update article markup at time of writing,
+// so complex selectors are needed to undo styles.
+.n-content-body {
+	.n-content-layout__slot,
+	.subhead--crosshead + .n-content-layout__slot,
+	.n-content-heading-2 + .n-content-layout__slot,
+	.subhead--standard + .n-content-layout__slot,
+	.n-content-heading-3 + .n-content-layout__slot,
+	.n-content-heading-4 + .n-content-layout__slot,
+	.n-content-heading-5 + .n-content-layout__slot {
+		margin-top: oSpacingByName('s1');
 		margin-bottom: oSpacingByName('s3');
+	}
+
+	.n-content-layout__slot {
+		> p,
+		> ul > li {
+			@include oTypographySans($scale: 1, $line-height: 22px);
+		}
+		> p {
+			margin-bottom: oSpacingByName('s3');
+		}
 	}
 }
 


### PR DESCRIPTION
**motivation**

Multiple teams/projects create article layouts. Customer products,
including `next-article` and `ft-app`; Spark for article preview;
interactive graphics.

Not all teams can depend on `n-content-body`, and trying to [may be
complex](https://github.com/Financial-Times/ft-app/blob/c6d89334b325edc2dfa625b878c19ba915d0fa4a/lib/css/article/main.scss#L74).

`o-editorial-layout` replaces parts of `n-content-body` for other
teams to use. However its difficult to update article markup for
existing `n-content-body` users. To make sure users of `n-content-body`
and `o-editorial-layout` are aligned, this PR uses `o-editorial-layout`
within the existing `n-content-body` interface.

In the future, replacing more `n-content-body` content with individual
components would allow more reuse. E.g. by breaking out layouts
including the timeline.

**notes**

- body typography styles are not applied directly to `p` elements,
these can be inherited from `.n-content-body`.
- the `strong` element is set to bold, rather than 600 (semibold)
since Georgia doesn't support semibold (no visual difference).
- `.n-content-layout__slot` is not excluded from having a top margin
if preceded by a heading, since `o-editorial-layout` cannot select
it without coupling the two projects implicity. Instead the margins
are reset. Ideally `n-content-layout__slot` would avoid the need
for overrides with markup changes, but that is currently difficult
for article content.
- `n-content-body__caption` does not use `o-editorial-layout`
as it is for table captions, where its siblings are table elements,
i.e. `tbody`

**screenshots**

To test I inspected the diff of `main.css` and compared screenshots when included in `next-article`.

before/after side-by-side, zoomed in:
![Screenshot 2020-10-08 at 11 48 36](https://user-images.githubusercontent.com/10405691/95462209-21eafc00-096f-11eb-86fd-8bfd0bcd999d.png)
![Screenshot 2020-10-08 at 11 47 08](https://user-images.githubusercontent.com/10405691/95462226-26171980-096f-11eb-9393-fff904624588.png)
![Screenshot 2020-10-08 at 11 46 53](https://user-images.githubusercontent.com/10405691/95462231-27484680-096f-11eb-9d6f-66f67ac005c6.png)

next-article, before:
![next-article-before](https://user-images.githubusercontent.com/10405691/95462433-69718800-096f-11eb-8502-0535c847094e.jpg)

next-article, after:
![next-article-after](https://user-images.githubusercontent.com/10405691/95462410-62e31080-096f-11eb-965d-278dfa907745.jpg)