### PR TITLE
CI-470 Extract width from video.scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ plus common / utility classes used across article elements
 
 ### v9 to v10
 
-v10 moves the responsibility of setting the width of embedded YouTube videos to the consumer, in relation to the 'n-content-video--youtube' class.
+v10 removes the width of embedded YouTube videos, in relation to the 'n-content-video--youtube' class. This is a design decision to make embedded YouTube videos consistently full-width. If you would like to replicate the old behaviour, you will have to set the width in the consumer repo.
 
-Below is an example of how to set the width in the consumer repo:
+Below is an example of how to replicate the old behaviour:
 ```
 .n-content-video--youtube {
 	width: 560px;

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ plus common / utility classes used across article elements
 
 ## Migration guides
 
+### v9 to v10
+
+v10 moves the responsibility of setting the width of embedded YouTube videos to the consumer, in relation to the 'n-content-video--youtube' class.
+
+Below is an example of how to set the width in the consumer repo:
+```
+.n-content-video--youtube {
+	width: 560px;
+}
+```
+
 ### v8 to v9
 
 v9 upgrades its version of `n-ui-foundations` from ^4.0.0 to ^6.0.0.

--- a/scss/_video.scss
+++ b/scss/_video.scss
@@ -13,10 +13,6 @@
 	width: 680px;
 }
 
-.n-content-video--youtube {
-	width: 560px;
-}
-
 .n-content-video__placeholder {
 	padding-top: 56.25%;
 


### PR DESCRIPTION
[Ticket.](https://financialtimes.atlassian.net/browse/CI-470)

YouTube videos are to be used with different widths in different places, so this PR extracts the width from the component so that we can set it where we use the component, giving greater flexibility.

To test:
- Navigate to a [live blog v2 with a YouTube video](https://local.ft.com:5050/content/b47a8dd0-81dc-4136-807c-c071c75c8fe2#post-750889ba-d5b6-41fb-88aa-d35aca642b79) (turn liveBlogsV2 on in toggler).
- Assert that YouTube videos are the full width of the article.

Needs to go live at the same time as this [PR](https://github.com/Financial-Times/next-article/pull/4122).