### PR TITLE
Require the latest version of o-editorial-layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
     "n-ui-foundations": "^6.0.0",
     "o-quote": "^4.1.2",
     "o-editorial-typography": "^1.1.0",
-    "o-editorial-layout": "^1.3.0"
+    "o-editorial-layout": "^1.4.1"
   }
 }


### PR DESCRIPTION
This will increase the bottom margin of h2 and h3 editorial headings.

Requested by Kevin (Editorial Creative Director) and Mus (Head of
Editorial Platforms).

https://github.com/Financial-Times/o-editorial-layout/pull/53