### PR TITLE
Remove promo box styles that should no longer be used

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -51,8 +51,6 @@
 		}
 	}
 
-	.n-content-related-box,
-	.n-content-related-box__image-link,
 	.n-content-copyright {
 		display: none;
 	}

--- a/scss/_related-box.scss
+++ b/scss/_related-box.scss
@@ -1,15 +1,6 @@
-.n-content-related-box,
 .n-content-info-box {
 	@include nContentBox;
 	border: 1px solid oColorsByName('black-20');
-}
-
-.n-content-related-box {
-	@include nContentBoxInline;
-
-	.o-expander__toggle {
-		margin-left: 16px;
-	}
 }
 
 .n-content-info-box {
@@ -17,22 +8,6 @@
 	padding-right: 16px;
 }
 
-.n-content-related-box__title {
-	@include nContentBoxTitle;
-}
-
-.n-content-related-box__title-text {
-	@include nContentBoxTitleText;
-	background-color: oColorsByName('paper');
-}
-
-.n-content-related-box__image-link {
-	.core & {
-		display: none;
-	}
-}
-
-.n-content-related-box__headline,
 .n-content-info-box__headline {
 	@include oTypographySans($weight: 'bold', $scale: 4);
 	font-size: 26px;
@@ -46,7 +21,6 @@
 	}
 }
 
-.n-content-related-box__content,
 .n-content-info-box__content {
 	margin-left: 16px;
 	margin-right: 16px;


### PR DESCRIPTION
These promo boxes are now removed in ES-interface so the styles shouldn't be used anymore

https://github.com/Financial-Times/next-es-interface/pull/1645