### PR TITLE
Remove the snyk step from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,6 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/n-content-body
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public


### PR DESCRIPTION
The snyk step is currently preventing this component from publishing as it errors with `Unexpected token *`

We can't seem to figure out why this is happening as it works locally.

This component doesn't have any dependencies anyway that would be tested by snyk and I don't imagine any being added in the future due to what the component is used for so removing this step should have no impact.