### PR TITLE
Remove overflow hidden on heading level 2

### DIFF
--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -2,8 +2,6 @@
 
 @mixin nContentHeading2 {
 	@include oEditorialLayoutHeading($level: 2);
-	// trigger a new formatting context so it won't run into floats
-	overflow: hidden;
 }
 
 @mixin nContentHeading3 {


### PR DESCRIPTION
This was added a long time ago and I don't think the situation it was added for exists any longer regarding running into floats.

This style is not added to any other heading level which can be used in the same context as a heading level 2 so I am going to try removing it and monitor the impact.

By removing this it will allow us to use `scroll-margin-top` to offset the scroll positions of headings so that when we link to headings using # in the url they are not hidden behind the sticky navigation