### PR TITLE
Prevent linked to headings from being hidden by sticky nav

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "n-ui-foundations": "^6.0.0",
     "o-quote": "^4.1.2",
     "o-editorial-typography": "^1.2.1",
-    "o-editorial-layout": "^1.5.0"
+    "o-editorial-layout": "^1.5.0",
+    "o-header": "^8.6.0"
   }
 }

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -1,19 +1,27 @@
 @import "o-editorial-layout/main";
 
+// Make sure when linking to a specific heading in an article that its not covered by the sticky nav
+@import 'o-header/main';
+$heading-height-with-spacing: $o-header-sticky-height + oSpacingByName('s4');
+
 @mixin nContentHeading2 {
 	@include oEditorialLayoutHeading($level: 2);
+	scroll-margin-top: $heading-height-with-spacing;
 }
 
 @mixin nContentHeading3 {
 	@include oEditorialLayoutHeading($level: 3);
+	scroll-margin-top: $heading-height-with-spacing;
 }
 
 @mixin nContentHeading4 {
 	@include oEditorialLayoutHeading($level: 4);
+	scroll-margin-top: $heading-height-with-spacing;
 }
 
 @mixin nContentHeading5 {
 	@include oEditorialLayoutHeading($level: 5);
+	scroll-margin-top: $heading-height-with-spacing;
 }
 
 /// @deprecated - Use o-editorial-layout instead.


### PR DESCRIPTION
Adding scroll-margin-top means that when someone uses a url with a # in it that links to a specific heading
that heading wont be hidden behind the sticky navigation at the top of the page

**Screenshot before change**
The below image shows the heading behind the sticky navigation when the user navigates to a url with a hash jump link in it

<img width="459" alt="Screenshot 2021-12-03 at 10 08 03" src="https://user-images.githubusercontent.com/524573/144585128-249c197f-5ffd-4bac-8002-9a63feea8bb1.png">


**Screenshot after change**
The below image shows the heading is no longer behind the sticky navigation when the user navigates to a url with a hash jump link in it

<img width="461" alt="Screenshot 2021-12-03 at 10 08 31" src="https://user-images.githubusercontent.com/524573/144585232-59d59151-4b9f-4d5d-814a-4fa993363b3c.png">


**Limitations**

This wont work in some much older browsers such as IE11 (hopefully being dropped soon 🤞) but it will just fall back to the behaviour before this change. This feels acceptable in those minor cases.