### PR TITLE
Add height: auto to images

### DIFF
--- a/scss/_images.scss
+++ b/scss/_images.scss
@@ -11,6 +11,7 @@
     display: block;
     margin: 0 auto;
     max-width: 100%;
+    height: auto;
   }
 }
 
@@ -50,5 +51,6 @@
     display: block;
     margin: 0 auto;
     max-width: 100%;
+    height: auto;
   }
 }


### PR DESCRIPTION
Currently on ft.com we don't set a height attribute on body images.

With the cp-content-pipeline, we plan to add a width/height attribute, so that the appropriate space is reserved (which is what the app currently does).

For this to work, we need to set `height: auto` in the CSS for images, so that the rendered aspect ratio remains the same.

This should have no impact on current image rendering, as we're not setting `height` on the image tag.