### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* @Financial-Times/content-innovation
+* @Financial-Times/storytelling


### PR DESCRIPTION
As part of the Storytelling Team name change ([ticket](https://financialtimes.atlassian.net/browse/CI-1318)), The Github team name is updated to storytelling and [all the projects](https://biz-ops.in.ft.com/GithubTeam/Financial-Times%2Fcontent-innovation#general) with CODEOWNERS must to be updated.