### PR TITLE
Update the n-content-recommended styles

### DIFF
--- a/scss/_recommended.scss
+++ b/scss/_recommended.scss
@@ -34,8 +34,20 @@
   }
 }
 
-.n-content-recommended__title {
-  @include oTypographySans($weight: "semibold", $scale: 1);
+.n-content-recommended {
+  &--single-story {
+    @include nLayoutInset;
 
-  margin-top: 4px;
+    .o-teaser__meta,
+    .o-teaser__heading {
+      @include oTypographySans(0);
+    }
+  }
+
+  &__title {
+    @include oTypographySans($weight: "semibold", $scale: 1);
+
+    margin-top: 4px;
+    margin-bottom: 0.83em;
+  }
 }


### PR DESCRIPTION
Updates the .n-content-recommended styles for `.n-content-recommended--single-story` and `.n-content-recommended__title` to reduce duplication between next-article and the app when the [cp-content-pipeline UI](https://github.com/Financial-Times/cp-content-pipeline/tree/main/packages/ui) gets implemented. 

These styles are already present in [next-article](https://github.com/Financial-Times/next-article/blob/main/client/components/article/_main.scss)