### PR TITLE
Use semibold for pullquote weight

### DIFF
--- a/scss/_pullquotes.scss
+++ b/scss/_pullquotes.scss
@@ -15,7 +15,7 @@
 }
 
 .n-content-pullquote__content {
-  @include oTypographySans($scale: 3, $weight: "bold");
+  @include oTypographySans($scale: 3, $weight: "semibold");
 
   margin-bottom: oSpacingByName("s4");
   padding-right: 16px;


### PR DESCRIPTION
> **[@notlee]** says:
> I can confirm this should be semibold and not bold. It's a regression introduced during the 2019 major cascade. @include oTypographySansBold(); should have been replaced with @include oTypographySans($weight: 'semibold');

The bold weight of Sans isn't loaded on articles anyway, so this won't make a visible difference on ft.com

(Spark uses the ft.com article CSS but it loads every font for fun)