### PR TITLE
refactor: move style from n-clip to n-content-body

### DIFF
--- a/scss/layout/_widths.scss
+++ b/scss/layout/_widths.scss
@@ -1,3 +1,17 @@
+.n-content-layout {
+  &__container--in-line {
+    margin-bottom: 1em;  // same as n-content-image
+  }
+
+  &__container--mid-grid {
+    @include oGridRespondTo($until: L) {
+      padding: 0;
+    }
+
+    margin-bottom: 1em;
+  }
+}
+
 .n-content-layout-set,
 .n-content-layout {
   clear: both;


### PR DESCRIPTION
[Ticket](https://financialtimes.atlassian.net/browse/CI-1690) 

Moved [this](https://github.com/Financial-Times/n-clip/blob/main/client/main.scss#L10) style to here. 

After this is merged, merge these in order:
- next-article: a PR bumping up n-content-body, to include the new styles
- ft-app: a PR bumping up n-content-body, to include the new styles
- n-clip: [PR](https://github.com/Financial-Times/n-clip/pull/29) replacing o-clip__container--* with these n-content-layout__container* CSS class names in the template, removing unused styles o-clip__container--*
- next-es-interface: a PR bumping up n-clip, to include the new HTML

Phase 2: (Only do this after the above is released and tested to ensure backward compatibility)
- next-article: a PR bumping up n-clip, to remove the o-clip__container--* unused styles
- ft-app: a PR bumping up n-clip, to remove the o-clip__container--* unused styles